### PR TITLE
fix(font size option not working)

### DIFF
--- a/src/annotationProvider.ts
+++ b/src/annotationProvider.ts
@@ -11,6 +11,8 @@ export class Annotations {
         message: string,
         range: Range
     ): DecorationOptions {
+        const fontSize = workspace.getConfiguration("inline-parameters").get("fontSize")
+
         return {
             range,
             renderOptions: {
@@ -20,7 +22,7 @@ export class Annotations {
                     backgroundColor: new ThemeColor("inlineparameters.annotationBackground"),
                     fontStyle: workspace.getConfiguration("inline-parameters").get("fontStyle"),
                     fontWeight: workspace.getConfiguration("inline-parameters").get("fontWeight"),
-                    fontSize: workspace.getConfiguration("inline-parameters").get("fontSize") + "px",
+                    textDecoration: `;font-size:${fontSize}px;`,
                 },
             } as DecorationInstanceRenderOptions,
         } as DecorationOptions


### PR DESCRIPTION
Closes #4.

Looks like the `fontSize` property has no effect anymore. I took a look at how the Error Lens extension handles their font sizes, and they use the `textDecoration` property with manual CSS.