### PR TITLE
Get one function's all parameters in one call

### DIFF
--- a/src/drivers/javascript.ts
+++ b/src/drivers/javascript.ts
@@ -1,5 +1,5 @@
 import { parse as abstractParse } from './abstract-javascript'
-export { getParameterName } from './abstract-javascript'
+export { getParameterNameList } from './abstract-javascript'
 
 export function parse(code: string) {
     return abstractParse(code, {

--- a/src/drivers/javascriptreact.ts
+++ b/src/drivers/javascriptreact.ts
@@ -1,5 +1,5 @@
 import { parse as abstractParse } from './abstract-javascript'
-export { getParameterName } from './abstract-javascript'
+export { getParameterNameList } from './abstract-javascript'
 
 export function parse(code: string) {
     return abstractParse(code, {

--- a/src/drivers/typescript.ts
+++ b/src/drivers/typescript.ts
@@ -1,5 +1,5 @@
 import { parse as abstractParse } from './abstract-javascript'
-export { getParameterName } from './abstract-javascript'
+export { getParameterNameList } from './abstract-javascript'
 
 export function parse(code: string) {
     return abstractParse(code, {

--- a/src/drivers/typescriptreact.ts
+++ b/src/drivers/typescriptreact.ts
@@ -1,5 +1,5 @@
 import { parse as abstractParse } from './abstract-javascript'
-export { getParameterName } from './abstract-javascript'
+export { getParameterNameList } from './abstract-javascript'
 
 export function parse(code: string) {
     return abstractParse(code, {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,8 +22,8 @@ export interface ParameterPosition {
 }
 
 export interface LanguageDriver {
-    getParameterName(editor: vscode.TextEditor, position: vscode.Position, key: number, namedValue?: string): any
-    parse(code: string): ParameterPosition[]
+    getParameterNameList(editor: vscode.TextEditor, languageParameters: ParameterPosition[]): Promise<(string | undefined)[]>
+    parse(code: string): ParameterPosition[][]
 }
 
 export function removeShebang(sourceCode: string): string {


### PR DESCRIPTION
Instead of extract parameter names for each parameter, I change it to extract parameter names for each function. It can save a lot of CPU time.