### PR TITLE
Fix casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ You can change the default foreground and background colours in the `workbench.c
 
 | Name | Description |
 |------|-------------|
-| `inlineparameters.annotationForeground` | Specifies the foreground colour for the annotations |
-| `inlineparameters.annotationBackground` | Specifies the background colour for the annotations |
+| `inlineParameters.annotationForeground` | Specifies the foreground colour for the annotations |
+| `inlineParameters.annotationBackground` | Specifies the background colour for the annotations |
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     ],
     "colors": [
       {
-        "id": "inlineparameters.annotationForeground",
+        "id": "inlineParameters.annotationForeground",
         "description": "Specifies the foreground color for the annotations",
         "defaults": {
           "dark": "#adbec5",
@@ -144,7 +144,7 @@
         }
       },
       {
-        "id": "inlineparameters.annotationBackground",
+        "id": "inlineParameters.annotationBackground",
         "description": "Specifies the background color for the annotations",
         "defaults": {
           "dark": "#1e2c31",

--- a/src/annotationProvider.ts
+++ b/src/annotationProvider.ts
@@ -16,8 +16,8 @@ export class Annotations {
             renderOptions: {
                 before: {
                     contentText: message,
-                    color: new ThemeColor("inlineparameters.annotationForeground"),
-                    backgroundColor: new ThemeColor("inlineparameters.annotationBackground"),
+                    color: new ThemeColor("inlineParameters.annotationForeground"),
+                    backgroundColor: new ThemeColor("inlineParameters.annotationBackground"),
                     fontStyle: workspace.getConfiguration("inline-parameters").get("fontStyle"),
                     fontWeight: workspace.getConfiguration("inline-parameters").get("fontWeight"),
                     textDecoration: `;


### PR DESCRIPTION
Rename occurrences of `inlineparameters` to `inlineParameters` to match style of VSCode's settings casing.